### PR TITLE
State what required key is missing a value.

### DIFF
--- a/yaml_conversion/lib/google/appengine/api/validation.py
+++ b/yaml_conversion/lib/google/appengine/api/validation.py
@@ -679,7 +679,7 @@ class Type(Validator):
     """
     if not isinstance(value, self.expected_type):
       if value is None:
-        raise MissingAttribute('Missing value is required.')
+        raise MissingAttribute("Missing required value '%s'." % key)
 
       if self.convert:
         try:


### PR DESCRIPTION
The error message for the `MissingAttribute` that is raised in `Type.Validate` is not very descriptive. It would be better if it mentioned the key that it could not find a value for. 

```python
       if value is None: 
         raise MissingAttribute('Missing value is required.') 
```

`Validated.CheckInitialized` has an example of a more ideal error message:

```python
       except MissingAttribute, e: 
         e.message = "Missing required value '%s'." % key 
         raise e 
```

With a more descriptive message, users will more clearly see where validation failed. The current implementation is too vague.